### PR TITLE
test (cypress-prod.yml): running test in prod upon merge to main

### DIFF
--- a/.github/workflows/cypress-prod.yml
+++ b/.github/workflows/cypress-prod.yml
@@ -1,5 +1,10 @@
-name: Cypress Tests
-on: [push]
+name: Cypress Tests - Prod
+
+on:
+  push:
+    branches:
+      - main
+
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
@@ -7,17 +12,26 @@ jobs:
       fail-fast: false
       matrix:
         containers: [1, 2]
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16' # Specify your Node.js version
+
+      - name: Install dependencies
+        run: yarn install
+
       - name: Cypress run in Prod
         uses: cypress-io/github-action@v6
-        run: npx cypress run
         with:
           record: true
           parallel: true
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          GITHUB_TOKEN: ${{ secrets.CYPRESS_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_BASE_URL: https://api.realworld.io/api
           CYPRESS_PREFIX: test-prod


### PR DESCRIPTION
## 🚀 Update Cypress Tests Workflow for Production

## 🔄 What's Changed:
Workflow Name: Cypress Tests - Prod
Trigger: On push to main
Parallel Execution: Run on 2 containers for faster tests

## 📝 Steps:
🔍 Checkout Code: actions/checkout@v2
⚙️ Set Up Node.js: actions/setup-node@v2 (Node 16)
📦 Install Dependencies: yarn install
🌀 Run Cypress: cypress-io/github-action@v6
Record: true
Environment: Configured with necessary secrets and variables

## 📝 Reason:
Enhance CI efficiency and speed by utilizing parallel test execution and recording results in Cypress Cloud.

